### PR TITLE
Make sure no instruction set notes are missing

### DIFF
--- a/lyah/mat/mat4x4.hpp
+++ b/lyah/mat/mat4x4.hpp
@@ -26,8 +26,8 @@ namespace lyah {
 			};
 		}
 
-		// NOTE: Axis must be already normalized.
-		// NOTE: Angle must be given in radians.
+		// axis is assumed to be normalized.
+		// angle is in radians.
 		LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL rotation(vec<3, T> axis, T angle) {
 			const T cosAngle = cos(angle);
 			const T sinAngle = sin(angle);
@@ -50,7 +50,7 @@ namespace lyah {
 			};
 		}
 
-		// NOTE: Returns a left-handed matrix.
+		// Returns a left-handed matrix.
 		LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL orthographic(T left, T right, T bottom, T top, T near, T far) {
 			const vec<4, T> m0 = vec<4, T>(static_cast<T>(2), static_cast<T>(0), static_cast<T>(0), -(left + right)) / (right - left);
 			const vec<4, T> m1 = vec<4, T>(static_cast<T>(0), static_cast<T>(2), static_cast<T>(0), -(bottom + top)) / (top - bottom);
@@ -60,7 +60,7 @@ namespace lyah {
 			return {m0, m1, m2, m3};
 		}
 
-		// NOTE: Returns a left-handed matrix.
+		// Returns a left-handed matrix.
 		LYAH_NODISCARD LYAH_INLINE static mat<4, 4, T> LYAH_CALL lookAt(vec<3, T> eye, vec<3, T> center, vec<3, T> up) {
 			const vec<3, T> f = normalized(center - eye);
 			const vec<3, T> r = normalized(cross(up, f));
@@ -92,8 +92,8 @@ namespace lyah {
 
 		LYAH_NODISCARD LYAH_INLINE mat(vec<4, T> m0, vec<4, T> m1, vec<4, T> m2, vec<4, T> m3) : m{m0, m1, m2, m3} {}
 
-		// Returns a rotation matrix computed from the quaternion a.
-		// NOTE: Assumes a is normalized.
+		// Returns a rotation matrix computed from a.
+		// a is assumed to be normalized.
 		LYAH_NODISCARD explicit mat(quat<T> a);
 
 		template<typename U>

--- a/lyah/types.hpp
+++ b/lyah/types.hpp
@@ -12,6 +12,7 @@ namespace lyah {
 
 		template<>
 		struct quat_t<std::float_t> {
+			// NOTE: SSE
 			using m_t = __m128;
 
 			// NOTE: SSE
@@ -31,6 +32,7 @@ namespace lyah {
 
 		template<>
 		struct quat_t<std::double_t> {
+			// NOTE: AVX
 			using m_t = __m256d;
 
 			// NOTE: AVX
@@ -53,11 +55,13 @@ namespace lyah {
 
 		template<>
 		struct vec_t<2, std::float_t> {
+			// NOTE: SSE
 			using m_t = __m128;
 		};
 
 		template<>
 		struct vec_t<3, std::float_t> {
+			// NOTE: SSE
 			using m_t = __m128;
 
 			// NOTE: SSE2
@@ -70,16 +74,19 @@ namespace lyah {
 
 		template<>
 		struct vec_t<4, std::float_t> {
+			// NOTE: SSE
 			using m_t = __m128;
 		};
 
 		template<>
 		struct vec_t<2, std::double_t> {
+			// NOTE: SSE2
 			using m_t = __m128d;
 		};
 
 		template<>
 		struct vec_t<3, std::double_t> {
+			// NOTE: AVX
 			using m_t = __m256d;
 
 			// NOTE: AVX
@@ -92,21 +99,25 @@ namespace lyah {
 
 		template<>
 		struct vec_t<4, std::double_t> {
+			// NOTE: AVX
 			using m_t = __m256d;
 		};
 
 		template<>
 		struct vec_t<4, std::int32_t> {
+			// NOTE: SSE2
 			using m_t = __m128i;
 		};
 
 		template<>
 		struct vec_t<2, std::int64_t> {
+			// NOTE: SSE2
 			using m_t = __m128i;
 		};
 
 		template<>
 		struct vec_t<4, std::int64_t> {
+			// NOTE: AVX
 			using m_t = __m256i;
 		};
 	}

--- a/lyah/vec/m128/geometric.ipp
+++ b/lyah/vec/m128/geometric.ipp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 namespace lyah {
+	// NOTE: SSE
 	// http://www.codersnotes.com/notes/maths-lib-2016
 	// https://geometrian.com/programming/tutorials/cross-product/index.php
 	LYAH_NODISCARD LYAH_INLINE vec<3, std::float_t> LYAH_CALL cross(vec<3, std::float_t> a, vec<3, std::float_t> b) {

--- a/lyah/vec/m128i/base.ipp
+++ b/lyah/vec/m128i/base.ipp
@@ -93,12 +93,12 @@ namespace lyah {
 		return a;
 	}
 
-	// NOTE: SSE2/SSE4.1
+	// NOTE: SSE2
 	// https://stackoverflow.com/a/17268337/17136841
 	// https://github.com/vectorclass/version2/blob/f4617df57e17efcd754f5bbe0ec87883e0ed9ce6/vectori128.h#L3108
 	template<std::size_t C>
 	LYAH_INLINE vec<C, std::int32_t>& LYAH_CALL operator *=(vec<C, std::int32_t>& a, vec<C, std::int32_t> b) {
-		#if LYAH_INT32_MAX_INSTRUCTION_SET < LYAH_INSTRUCTION_SET_SSE4_1
+		//#if LYAH_INT32_MAX_INSTRUCTION_SET < LYAH_INSTRUCTION_SET_SSE4_1
 			const __m128i m0 = _mm_mul_epu32(a.m, b.m);
 
 			const __m128i m1l = _mm_shuffle_epi32(a.m, _MM_SHUFFLE(3, 3, 1, 1));
@@ -109,9 +109,10 @@ namespace lyah {
 			const __m128i h = _mm_unpackhi_epi32(m0, m1);
 
 			a.m = _mm_unpacklo_epi64(l, h);
-		#else
+		/*#else
+			// NOTE: SSE4.1
 			a.m = _mm_mullo_epi32(a.m, b.m);
-		#endif
+		#endif*/
 
 		return a;
 	}

--- a/lyah/vec/vec.hpp
+++ b/lyah/vec/vec.hpp
@@ -4,11 +4,9 @@
 #pragma once
 
 namespace lyah {
-	// fwd
 	template<std::size_t M, std::size_t N, typename T>
 	struct mat;
 
-	// fwd
 	template<typename T>
 	struct quat;
 


### PR DESCRIPTION
Add missing notes and rewrite use criteria for matrix utilities.