### PR TITLE
Remove comments about bitmasking integer vector comparison

### DIFF
--- a/lyah/vec/m128i/base.ipp
+++ b/lyah/vec/m128i/base.ipp
@@ -10,7 +10,6 @@ namespace lyah {
 		return mask == 0xffff;
 	}
 
-	// TODO: Apply bitmask.
 	// NOTE: SSE2
 	// https://stackoverflow.com/a/26881190/17136841
 	template<std::size_t C>
@@ -29,7 +28,6 @@ namespace lyah {
 		return mask != 0xffff;
 	}
 
-	// TODO: Apply bitmask.
 	// NOTE: SSE2
 	// https://stackoverflow.com/a/26881190/17136841
 	template<std::size_t C>

--- a/lyah/vec/m256i/base.ipp
+++ b/lyah/vec/m256i/base.ipp
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 namespace lyah {
-	// TODO: Apply bitmask.
 	// NOTE: AVX2
 	// https://stackoverflow.com/a/26881190/17136841
 	template<std::size_t C>
@@ -13,7 +12,6 @@ namespace lyah {
 		return mask == -1;
 	}
 
-	// TODO: Apply bitmask.
 	// NOTE: AVX2
 	// https://stackoverflow.com/a/26881190/17136841
 	template<std::size_t C>


### PR DESCRIPTION
Since integer vectors sizes are optimal for the SIMD data type, bitmasks are unneeded when comparing.